### PR TITLE
script to start dev resources covers all the endpoints now; cleaner h…

### DIFF
--- a/documentation/development_workflow.md
+++ b/documentation/development_workflow.md
@@ -79,7 +79,13 @@ see [setup_dev_environment.md](setup_dev_environment.md) if you're just starting
    ```powershell
    .\scripts\start-dev-resources.ps1
    ```
-This spins up all the AWS resources needed.
+This spins up all the AWS resources needed EXCEPT a bastion instance. The bastion instance is handled separately via
+   ```powershell
+   .\scripts\start-bastion-for-dev.ps1
+   ```
+because in many development sessions the bastion is not needed.
+
+NOTE: the standard stop-dev-resources script will stop the bastion instance (in addition to everything else), but if you want to stop only bastion and not the other services, use `stop-bastion-for-dev.ps1`.
 
 2. **Setup local services (in local services terminal)**
    ```powershell
@@ -99,7 +105,7 @@ if needed, start frontend (in separate terminal) - this is useful when doing pur
    ```powershell
    .\scripts\stop-dev-resources.ps1
    ```
-This spins down all the AWS resources that incur on-going, passive costs
+This spins down all the AWS resources (INCLUDING the bastion instance) that incur on-going, passive costs
 
 ## Testing
 

--- a/scripts/start-bastion-for-dev.ps1
+++ b/scripts/start-bastion-for-dev.ps1
@@ -1,0 +1,88 @@
+# Start Bastion for Dev Script
+# This script starts the bastion EC2 instance for database access during development.
+# Resource config is loaded from dev-resource-ids.ps1 (which should be in .gitignore)
+
+# NOTE: This script assumes the bastion infrastructure is already set up via Terraform.
+# It only starts the existing bastion instance.
+
+# NOTE: This script is designed to be run in a PowerShell environment with AWS CLI 
+# installed. If translating this to work in another environment (like Bash), the commands and syntax will
+# need to be adjusted accordingly.
+
+# TO RUN:
+# 1. navigate to the scripts directory
+# 2. run: .\start-bastion-for-dev.ps1
+
+$idsPath = Join-Path $PSScriptRoot 'dev-resource-ids.ps1'
+if (Test-Path $idsPath) {
+    # Load the config file to set environment variables
+    Get-Content $idsPath | Out-String | Invoke-Expression
+} else {
+    Write-Error "Missing dev-resource-ids.ps1. Please create it with your resource IDs."
+    exit 1
+}
+
+# Assign config values to local variables for clarity
+$region = $env:CHOREGARDEN_REGION
+$awsProfile = $env:CHOREGARDEN_PROFILE
+$bastionNameTag = $env:CHOREGARDEN_BASTION_NAME_TAG
+
+# Auto-discover Bastion instance ID and state by Name tag
+$bastionInfo = aws ec2 describe-instances --region $region --profile $awsProfile --filters "Name=tag:Name,Values=$bastionNameTag" "Name=instance-state-name,Values=running,stopped" | ConvertFrom-Json | Select-Object -ExpandProperty Reservations | ForEach-Object { $_.Instances } | Where-Object { $_ } | Select-Object -First 1
+
+$bastionInstanceId = $bastionInfo.InstanceId
+$bastionState = $bastionInfo.State.Name
+$bastionPublicIp = $bastionInfo.PublicIpAddress
+
+Write-Host "Region: $region"
+Write-Host "Profile: $awsProfile"
+Write-Host "Bastion Name Tag: $bastionNameTag"
+Write-Host "Bastion Instance ID: $bastionInstanceId"
+Write-Host "Bastion State: $bastionState"
+
+# Handle Bastion EC2 instance based on current state
+if ($bastionInstanceId) {
+    if ($bastionState -eq "running") {
+        Write-Host ""
+        Write-Host "Bastion instance is already running!"
+        Write-Host "Instance ID: $bastionInstanceId"
+        Write-Host "Public IP: $bastionPublicIp"
+        Write-Host ""
+        Write-Host "To connect to the bastion for database access:"
+        Write-Host "1. Use AWS Systems Manager Session Manager to connect"
+        Write-Host "2. Or use SSH if you have the key pair configured"
+        Write-Host "   ssh -i ~/.ssh/choregarden-bastion-dev.pem ec2-user@$bastionPublicIp"
+    } elseif ($bastionState -eq "stopped") {
+        Write-Host "Starting bastion instance..."
+        aws ec2 start-instances --instance-ids $bastionInstanceId --region $region --profile $awsProfile | Out-Host
+        
+        Write-Host ""
+        Write-Host "Bastion instance starting successfully!"
+        Write-Host "Instance ID: $bastionInstanceId"
+        Write-Host ""
+        Write-Host "To connect to the bastion for database access:"
+        Write-Host "1. Wait for instance to reach 'running' state (check AWS console)"
+        Write-Host "2. Use AWS Systems Manager Session Manager to connect"
+        Write-Host "3. Or use SSH if you have the key pair configured"
+    } else {
+        Write-Warning "Bastion instance is in '$bastionState' state. Cannot start."
+        Write-Host "Wait for the instance to reach 'stopped' state before trying to start it."
+    }
+} else {
+    Write-Warning "No Bastion instance found with Name tag '$bastionNameTag'"
+    Write-Host ""
+    Write-Host "The bastion instance needs to be created first via Terraform."
+    Write-Host ""
+    Write-Host "To create the bastion temporarily (without modifying terraform.tfvars):"
+    Write-Host '  cd infrastructure/envs/dev'
+    Write-Host '  terraform apply -var="create_bastion=true"'
+    Write-Host "This creates the bastion instance, the relevant security groups, any necessary IAM roles, and updates any other security groups that depend on the bastion one (e.g. the backend and db security groups)."
+    Write-Host ""
+    Write-Host "NOTE: To fully destroy the bastion when done (to save long-term costs - this is probably not needed on scales of less than a year):"
+    Write-Host '  terraform destroy -var="create_bastion=true" -target="module.bastion"'
+    Write-Host ""
+    Write-Host "Other possible issues:"
+    Write-Host "- Instance doesn't have the expected Name tag: '$bastionNameTag'"
+    Write-Host "- AWS CLI profile or region configuration issue"
+    exit 1
+}

--- a/scripts/start-dev-resources.ps1
+++ b/scripts/start-dev-resources.ps1
@@ -1,6 +1,6 @@
 # Start Dev Resources Script
 # This script starts all dev resources: re-creates VPC interface endpoints (via Terraform),
-# starts RDS, ECS backend, and Bastion EC2 instance.
+# starts RDS, and ECS backend.
 # Resource config is loaded from dev-resource-ids.ps1 (which should be in .gitignore)
 
 # NOTE: this is intended to be run after `stop-dev-resources.ps1` to bring the dev environment
@@ -11,13 +11,16 @@
 # installed. If translating this to work in another environment (like Bash), the commands and syntax will
 # need to be adjusted accordingly.
 
+# NOTE: For bastion instance management, use the separate `start-bastion-for-dev.ps1` script.
+
 # TO RUN:
 # 1. navigate to the scripts directory
 # 2. run: .\start-dev-resources.ps1
 
 $idsPath = Join-Path $PSScriptRoot 'dev-resource-ids.ps1'
 if (Test-Path $idsPath) {
-    $config = Get-Content $idsPath | Out-String | Invoke-Expression
+    # Load the config file to set environment variables
+    Get-Content $idsPath | Out-String | Invoke-Expression
 } else {
     Write-Error "Missing dev-resource-ids.ps1. Please create it with your resource IDs."
     exit 1
@@ -25,25 +28,19 @@ if (Test-Path $idsPath) {
 
 # Assign config values to local variables for clarity
 $region = $env:CHOREGARDEN_REGION
-$profile = $env:CHOREGARDEN_PROFILE
+$awsProfile = $env:CHOREGARDEN_PROFILE
 $rdsInstanceId = $env:CHOREGARDEN_RDS_INSTANCE_ID
 $ecsCluster = $env:CHOREGARDEN_ECS_CLUSTER
 $ecsService = $env:CHOREGARDEN_ECS_SERVICE
 
-# Auto-discover Bastion instance ID by Name tag
-$bastionNameTag = $env:CHOREGARDEN_BASTION_NAME_TAG
-$bastionInstanceId = aws ec2 describe-instances --region $region --profile $profile --filters "Name=tag:Name,Values=$bastionNameTag" "Name=instance-state-name,Values=running,stopped" | ConvertFrom-Json | Select-Object -ExpandProperty Reservations | ForEach-Object { $_.Instances } | Where-Object { $_ } | Select-Object -First 1 -ExpandProperty InstanceId
-
 Write-Host "Region: $region"
-Write-Host "Profile: $profile"
+Write-Host "Profile: $awsProfile"
 Write-Host "RDS Instance ID: $rdsInstanceId"
 Write-Host "ECS Cluster: $ecsCluster"
 Write-Host "ECS Service: $ecsService"
-Write-Host "Bastion Name Tag: $bastionNameTag"
-Write-Host "Bastion Instance ID: $bastionInstanceId"
 
 # 1. Re-create VPC endpoints, VPC Link, NLB, and API Gateway integrations/routes with Terraform
-$env:AWS_PROFILE = $profile
+$env:AWS_PROFILE = $awsProfile
 cd $PSScriptRoot/../infrastructure/envs/dev
 terraform apply -auto-approve `
   "-target=aws_vpc_endpoint.secretsmanager" `
@@ -55,19 +52,20 @@ terraform apply -auto-approve `
   "-target=module.app_backend.aws_lb_target_group.backend" `
   "-target=module.app_backend.aws_lb_listener.backend" `
   "-target=module.api_gateway.aws_apigatewayv2_integration.backend_vpc" `
-  "-target=module.api_gateway.aws_apigatewayv2_route.ping" `
-  "-target=module.api_gateway.aws_apigatewayv2_route.pingdeep"
+  "-target=module.api_gateway.aws_apigatewayv2_route.public" `
+  "-target=module.api_gateway.aws_apigatewayv2_route.protected" `
+  "-target=module.api_gateway.aws_apigatewayv2_route.options"
 cd $PSScriptRoot
 
 # 2. Start RDS instance
-aws rds start-db-instance --db-instance-identifier $rdsInstanceId --region $region --profile $profile | Out-Host
+aws rds start-db-instance --db-instance-identifier $rdsInstanceId --region $region --profile $awsProfile | Out-Host
 
 # 3. Scale up ECS service
-aws ecs update-service --cluster $ecsCluster --service $ecsService --desired-count 1 --region $region --profile $profile | Out-Host
+aws ecs update-service --cluster $ecsCluster --service $ecsService --desired-count 1 --region $region --profile $awsProfile | Out-Host
 
-# 4. Start Bastion EC2 instance
-if ($bastionInstanceId) {
-    aws ec2 start-instances --instance-ids $bastionInstanceId --region $region --profile $profile | Out-Host
-} else {
-    Write-Warning "No Bastion instance found with Name tag '$bastionNameTag'"
-}
+Write-Host "Dev resources started successfully!"
+Write-Host "- VPC endpoints and API Gateway routes: Created/Updated"
+Write-Host "- RDS instance: Starting"
+Write-Host "- ECS service: Scaled to 1 instance"
+Write-Host ""
+Write-Host "To start the bastion instance for database access, run: .\start-bastion-for-dev.ps1"

--- a/scripts/stop-bastion-for-dev.ps1
+++ b/scripts/stop-bastion-for-dev.ps1
@@ -1,0 +1,82 @@
+# Stop Bastion for Dev Script
+# This script stops the bastion EC2 instance to save costs when not needed for database access.
+# Resource config is loaded from dev-resource-ids.ps1 (which should be in .gitignore)
+
+# NOTE: This script only stops the instance (preserves it for quick restart).
+# It does NOT destroy the bastion infrastructure.
+
+# NOTE: This script is designed to be run in a PowerShell environment with AWS CLI 
+# installed. If translating this to work in another environment (like Bash), the commands and syntax will
+# need to be adjusted accordingly.
+
+# TO RUN:
+# 1. navigate to the scripts directory
+# 2. run: .\stop-bastion-for-dev.ps1
+
+$idsPath = Join-Path $PSScriptRoot 'dev-resource-ids.ps1'
+if (Test-Path $idsPath) {
+    # Load the config file to set environment variables
+    Get-Content $idsPath | Out-String | Invoke-Expression
+} else {
+    Write-Error "Missing dev-resource-ids.ps1. Please create it with your resource IDs."
+    exit 1
+}
+
+# Assign config values to local variables for clarity
+$region = $env:CHOREGARDEN_REGION
+$awsProfile = $env:CHOREGARDEN_PROFILE
+$bastionNameTag = $env:CHOREGARDEN_BASTION_NAME_TAG
+
+# Auto-discover Bastion instance ID and state by Name tag
+$bastionInfo = aws ec2 describe-instances --region $region --profile $awsProfile --filters "Name=tag:Name,Values=$bastionNameTag" "Name=instance-state-name,Values=running,stopped" | ConvertFrom-Json | Select-Object -ExpandProperty Reservations | ForEach-Object { $_.Instances } | Where-Object { $_ } | Select-Object -First 1
+
+$bastionInstanceId = $bastionInfo.InstanceId
+$bastionState = $bastionInfo.State.Name
+
+Write-Host "Region: $region"
+Write-Host "Profile: $awsProfile"
+Write-Host "Bastion Name Tag: $bastionNameTag"
+Write-Host "Bastion Instance ID: $bastionInstanceId"
+Write-Host "Bastion State: $bastionState"
+
+# Handle Bastion EC2 instance based on current state
+if ($bastionInstanceId) {
+    if ($bastionState -eq "stopped") {
+        Write-Host ""
+        Write-Host "Bastion instance is already stopped!"
+        Write-Host "Instance ID: $bastionInstanceId"
+        Write-Host ""
+        Write-Host "To restart the bastion when needed:"
+        Write-Host "  .\start-bastion-for-dev.ps1"
+    } elseif ($bastionState -eq "running") {
+        Write-Host ""
+        Write-Host "Stopping bastion instance..."
+        aws ec2 stop-instances --instance-ids $bastionInstanceId --region $region --profile $awsProfile | Out-Host
+        
+        Write-Host ""
+        Write-Host "Bastion instance stopping successfully!"
+        Write-Host "Instance ID: $bastionInstanceId"
+        Write-Host ""
+        Write-Host "The instance will be preserved and can be restarted quickly when needed."
+        Write-Host "You will only be charged for EBS storage (~$0.80/month) while stopped."
+        Write-Host ""
+        Write-Host "To restart the bastion when needed:"
+        Write-Host "  .\start-bastion-for-dev.ps1"
+    } else {
+        Write-Warning "Bastion instance is in '$bastionState' state. Cannot stop."
+        Write-Host "Wait for the instance to reach 'running' state before trying to stop it."
+    }
+} else {
+    Write-Warning "No Bastion instance found with Name tag '$bastionNameTag'"
+    Write-Host ""
+    Write-Host "The bastion instance (and any associated thing like a security group) needs to be created first via Terraform."
+    Write-Host ""
+    Write-Host "To create the bastion temporarily (without modifying terraform.tfvars):"
+    Write-Host '  cd infrastructure/envs/dev'
+    Write-Host '  terraform apply -var="create_bastion=true"'
+    Write-Host ""
+    Write-Host "Other possible issues:"
+    Write-Host "- Instance doesn't have the expected Name tag: '$bastionNameTag'"
+    Write-Host "- AWS CLI profile or region configuration issue"
+    exit 1
+}

--- a/scripts/stop-dev-resources.ps1
+++ b/scripts/stop-dev-resources.ps1
@@ -22,9 +22,12 @@ $rdsInstanceId = $env:CHOREGARDEN_RDS_INSTANCE_ID
 $ecsCluster = $env:CHOREGARDEN_ECS_CLUSTER
 $ecsService = $env:CHOREGARDEN_ECS_SERVICE
 
-# Auto-discover Bastion instance ID by Name tag
+# Auto-discover Bastion instance ID and state by Name tag
 $bastionNameTag = $env:CHOREGARDEN_BASTION_NAME_TAG
-$bastionInstanceId = aws ec2 describe-instances --region $region --profile $profile --filters "Name=tag:Name,Values=$bastionNameTag" "Name=instance-state-name,Values=running,stopped" | ConvertFrom-Json | Select-Object -ExpandProperty Reservations | ForEach-Object { $_.Instances } | Where-Object { $_ } | Select-Object -First 1 -ExpandProperty InstanceId
+$bastionInfo = aws ec2 describe-instances --region $region --profile $profile --filters "Name=tag:Name,Values=$bastionNameTag" "Name=instance-state-name,Values=running,stopped" | ConvertFrom-Json | Select-Object -ExpandProperty Reservations | ForEach-Object { $_.Instances } | Where-Object { $_ } | Select-Object -First 1
+
+$bastionInstanceId = $bastionInfo.InstanceId
+$bastionState = $bastionInfo.State.Name
 
 Write-Host "Region: $region"
 Write-Host "Profile: $profile"
@@ -34,6 +37,7 @@ Write-Host "ECS Cluster: $ecsCluster"
 Write-Host "ECS Service: $ecsService"
 Write-Host "Bastion Name Tag: $bastionNameTag"
 Write-Host "Bastion Instance ID: $bastionInstanceId"
+Write-Host "Bastion State: $bastionState"
 
 # Dynamically look up VPC endpoint IDs by Name tag
 $vpcEndpointIds = @()
@@ -57,7 +61,14 @@ aws ecs update-service --cluster $ecsCluster --service $ecsService --desired-cou
 
 # 4. Stop Bastion EC2 instance
 if ($bastionInstanceId) {
-    aws ec2 stop-instances --instance-ids $bastionInstanceId --region $region --profile $profile | Out-Host
+    if ($bastionState -eq "stopped") {
+        Write-Host "Bastion instance is already stopped."
+    } elseif ($bastionState -eq "running") {
+        Write-Host "Stopping Bastion instance..."
+        aws ec2 stop-instances --instance-ids $bastionInstanceId --region $region --profile $profile | Out-Host
+    } else {
+        Write-Host "Bastion instance is in '$bastionState' state - skipping stop command."
+    }
 } else {
     Write-Warning "No Bastion instance found with Name tag '$bastionNameTag'"
 }

--- a/todo.txt
+++ b/todo.txt
@@ -1,13 +1,11 @@
 latest done:
-* setting up github OIDC for my deployments
-* deploy FE via ci-cd (to dev environment)
-
-in progress:
 * make FE deploy trigger only when there are changes in the /frontend folder tree
-
-next steps:
 * update the start-dev-resources script to create all the "aws_apigatewayv2_route"s
 * * also, do NOT spin up the bastion automatically (but create a separate script for that)
+
+in progress:
+
+next steps:
 * deploy BE via ci-cd (to dev environment)
 * DB change deployment and migration via CI-CD (to dev environment)
 * op lambdas deployments


### PR DESCRIPTION
…andling of starting and stopping the bastion resource - the bastion is NOT automatically started as a part of the standard dev resources because for many dev sessions it's not needed; there are separate start and stop scripts specific to bastion (though the general stop script also covers bastion as a part of stopping all dev resources)